### PR TITLE
Added www.ladepeche.fr to supported sites

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -40,6 +40,7 @@ This extension currently supports the following websites:
 * irishtimes.com
 * kansas.com
 * kansascity.com
+* www.ladepeche.fr
 * latimes.com
 * lanation.com.ar
 * letemps.ch

--- a/README.MD
+++ b/README.MD
@@ -40,7 +40,7 @@ This extension currently supports the following websites:
 * irishtimes.com
 * kansas.com
 * kansascity.com
-* www.ladepeche.fr
+* ladepeche.fr
 * latimes.com
 * lanation.com.ar
 * letemps.ch

--- a/background.js
+++ b/background.js
@@ -28,6 +28,7 @@ const websites = [
 	  "*://*.irishtimes.com/*",
 	  "*://*.kansas.com/*",
 	  "*://*.kansascity.com/*",
+	  "*://*.ladepeche.fr/*",
 	  "*://*.latimes.com/*",
 	  "*://*.lanacion.com.ar/*",
 	  "*://*.letemps.ch/*",
@@ -88,7 +89,7 @@ function evadePaywalls(details) {
 				break;
 			default:
 				return true;
-		} 
+		}
 	})
 
 	// Add the spoofed ones back
@@ -120,7 +121,7 @@ function blockCookies(details) {
 	var responseHeaders = details.responseHeaders.filter(function(header) {
 		if (header.name === "Cookie") {
 			return false;
-		} 
+		}
 
 		return true;
 	})


### PR DESCRIPTION
Hello,
I've added www.ladepeche.fr to supported websites so that this addon can be used to bypass paywall of this site.
Kind regards,